### PR TITLE
GUI fix for issue "mod changes style of non-mod GUI elements"

### DIFF
--- a/Source/FMRS_Core.cs
+++ b/Source/FMRS_Core.cs
@@ -1719,9 +1719,20 @@ namespace FMRS
             if (Debug_Active)
                 Debug.Log("#### FMRS: init_skin");
 
-            mySkin = HighLogic.Skin;
-            mySkin.button.fontSize = 15;
-            mySkin.textArea.fontSize = 15;
+//            mySkin = HighLogic.Skin;
+
+            mySkin = new GUISkin();
+            mySkin.button = new GUIStyle(HighLogic.Skin.button);
+            mySkin.textArea = new GUIStyle(HighLogic.Skin.textArea);
+            mySkin.scrollView = new GUIStyle(HighLogic.Skin.scrollView);
+            mySkin.box = new GUIStyle(HighLogic.Skin.box);
+            mySkin.label = new GUIStyle(HighLogic.Skin.label);
+            mySkin.textField = new GUIStyle(HighLogic.Skin.textField);
+            mySkin.toggle = new GUIStyle(HighLogic.Skin.toggle);
+            mySkin.window = new GUIStyle(HighLogic.Skin.window);
+
+//            mySkin.button.fontSize = 15;
+//            mySkin.textArea.fontSize = 15;
             mySkin.button.normal.textColor = Color.white;
             mySkin.button.hover.textColor = Color.yellow;
             mySkin.button.onNormal.textColor = Color.green;


### PR DESCRIPTION
The operator
"mySkin = HighLogic.Skin;"
copies only reference to HighLogic.Skin, not object itself.
So any changes you made with mySkin also affects HighLogic.Skin, which
changes the whole GUI of KSP

Changes of font size are commented out, because without it the text in mod's window becomes unexpectedly large.
Before commenting out 

```
        mySkin.button.fontSize = 15;
        mySkin.textArea.fontSize = 15;
```

![2014-11-17 21-25-09 kerbal space program](https://cloud.githubusercontent.com/assets/6450733/5090190/702f2a1c-6f51-11e4-9317-b9021699aabc.png)
After commenting out:
![2014-11-18 10-24-35 kerbal space program](https://cloud.githubusercontent.com/assets/6450733/5090201/8d8b5f5e-6f51-11e4-916a-8de46c0ded99.png)
